### PR TITLE
[MRQL-74] Update Flink version to 0.9.0

### DIFF
--- a/flink/src/main/java/org/apache/mrql/FlinkDataSource.java
+++ b/flink/src/main/java/org/apache/mrql/FlinkDataSource.java
@@ -87,6 +87,20 @@ final public class FlinkDataSource extends DataSource implements Serializable {
                                                                ((Reducer)other).accumulated_value.data())));
         }
 
+        @Override
+        public Accumulator<FData, String> clone() {
+            Reducer reducer = new Reducer();
+
+            reducer.zero = new FData(this.zero.data);
+            reducer.accumulated_value = new FData(accumulated_value.data);
+            reducer.acc = this.acc;
+            reducer.merge = this.merge;
+            reducer.acc_fnc = this.acc_fnc;
+            reducer.merge_fnc = this.merge_fnc;
+
+            return reducer;
+        }
+
         public void write ( DataOutputView out ) throws IOException {
             accumulated_value.write(out);
             zero.write(out);

--- a/flink/src/main/java/org/apache/mrql/FlinkEvaluator.gen
+++ b/flink/src/main/java/org/apache/mrql/FlinkEvaluator.gen
@@ -35,6 +35,7 @@ import org.apache.flink.api.java.*;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.functions.*;
 import org.apache.flink.api.java.operators.*;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -190,7 +191,8 @@ public class FlinkEvaluator extends Evaluator implements Serializable {
     private static MRData aggregate ( DataSet<FData> data_set, MRData zero, Tree acc_fnc, Tree merge_fnc, Tree type ) {
         DataSet<FData> d = data_set.flatMap(new FlinkDataSource.reduce_mapper(zero,acc_fnc.toString(),
                                                                               merge_fnc.toString()));
-        d.print();  // needs a datasink (prints the aggregation value)
+        //d.print();  // needs a datasink (prints the aggregation value)
+        d.output(new DiscardingOutputFormat());
         try {
             // due to a Flink bug, we cannot return a custom object (FData) from an accumulator
             String value = FlinkEvaluator.flink_env.execute("MRQL aggregator").getAccumulatorResult("reducer");

--- a/flink/src/main/java/org/apache/mrql/FlinkStreaming.gen
+++ b/flink/src/main/java/org/apache/mrql/FlinkStreaming.gen
@@ -28,7 +28,8 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.util.Collector;
 import org.apache.flink.streaming.api.datastream.*;
-import org.apache.flink.streaming.api.function.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
@@ -47,12 +48,14 @@ public class FlinkStreaming extends FlinkEvaluator {
 	final private String directory;
         final private long time_window;
         final private FileInputFormat<FData> input_format;
+        private boolean is_running;
 
 	public MRDataFileSourceFunction ( String directory, long time_window,
                                           FileInputFormat<FData> input_format ) {
             this.directory = directory;
             this.time_window = time_window;
             this.input_format = input_format;
+            this.is_running = false;
 	}
 
         /** return the files within the directory that have been created within the last time window */
@@ -85,10 +88,10 @@ public class FlinkStreaming extends FlinkEvaluator {
         }
 
 	@Override
-	public void invoke ( Collector<FData> collector ) throws IOException {
+	public void run ( SourceContext<FData> context ) throws Exception {
             long tick = System.currentTimeMillis();
             file_modification_times = new HashMap<String,Long>();
-            while (true) {
+            while (is_running) {
                 for ( String path: new_files() ) {
                     input_format.setFilePath(path);
                     FileInputSplit[] splits = input_format.createInputSplits(1);
@@ -97,7 +100,7 @@ public class FlinkStreaming extends FlinkEvaluator {
                         while (!input_format.reachedEnd()) {
                             FData fd = input_format.nextRecord(container);
                             if (fd != null)
-                                collector.collect(fd);
+                                context.collect(fd);
                         }
                     };
                     input_format.close();
@@ -112,6 +115,11 @@ public class FlinkStreaming extends FlinkEvaluator {
                     return;
                 }
             }
+	}
+
+	@Override
+	public void cancel() {
+	  is_running = false;
 	}
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <hama.version>0.6.4</hama.version>
     <spark.version>1.3.1</spark.version>
     <scala.version>2.10</scala.version>
-    <flink.version>0.8.1</flink.version>
+    <flink.version>0.9.0</flink.version>
     <skipTests>true</skipTests>
   </properties>
 
@@ -143,6 +143,8 @@
           <excludes>
 	    <exclude>.git/**</exclude>
 	    <exclude>.gitignore</exclude>
+            <exclude>.idea/**</exclude>
+            <exclude>**.iml</exclude>
             <exclude>.classpath/**</exclude>
             <exclude>.project/**</exclude>
             <exclude>tests/data/**</exclude>


### PR DESCRIPTION
This PR contains following changes:

* Update Flink version to 0.9.0.
* Change implementation of `Accumulator`, `SourceFunction`.
* Change output method from using `print` to using  `DiscardingOutputFormat`.
  * From Flink 0.9.0, `print()` method executes eagerly.