### PR TITLE
[MRQL-74] Update Flink version to 0.9.0

### DIFF
--- a/conf/mrql-env.sh
+++ b/conf/mrql-env.sh
@@ -34,7 +34,9 @@
 
 
 # Required: The Java installation directory
-JAVA_HOME=/root/jdk
+if [[ !(-f ${JAVA_HOME}) ]]; then
+   export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+fi
 
 # Required: The CUP parser library
 # You can download it from http://www2.cs.tum.edu/projects/cup/
@@ -46,7 +48,7 @@ JLINE_JAR=${HOME}/.m2/repository/jline/jline/1.0/jline-1.0.jar
 
 
 # Required: Hadoop configuration. Supports versions 1.x and 2.x (YARN)
-HADOOP_VERSION=2.2.0
+HADOOP_VERSION=2.6.0
 # The Hadoop installation directory
 HADOOP_HOME=${HOME}/hadoop-${HADOOP_VERSION}
 # The Hadoop configuration directory (where core-site.xml is)
@@ -92,9 +94,10 @@ SPARK_WORKER_CORES=1
 SPARK_WORKER_MEMORY=1G
 
 
-# Optional: Flink configuration. Supports versions 0.6-incubating, 0.6.1-incubating, 0.7.0-incubating, 0.8.0, and 0.8.1
+# Optional: Flink configuration. Supports version 0.9.0 only
+# (Flink versions 0.6-incubating, 0.6.1-incubating, 0.7.0-incubating, 0.8.0, and 0.8.1 are supported by MRQL 0.9.2)
 # Note: for yarn, set yarn.nodemanager.vmem-check-enabled to false in yarn-site.xml
-FLINK_VERSION=yarn-0.8.0
+FLINK_VERSION=0.9.0
 # Flink installation directory
 FLINK_HOME=${HOME}/flink-${FLINK_VERSION}
 # Hadoop HDFS: needed for Sequence files in Flink mode
@@ -109,7 +112,7 @@ fi
 
 HAMA_JAR=${HAMA_HOME}/hama-core-${HAMA_VERSION}.jar
 FLINK_JARS=.
-for I in ${FLINK_HOME}/lib/*.jar; do
+for I in ${FLINK_HOME}/lib/flink-dist*.jar; do
     FLINK_JARS=${FLINK_JARS}:$I
 done
 

--- a/core/src/test/java/org/apache/mrql/QueryTest.java
+++ b/core/src/test/java/org/apache/mrql/QueryTest.java
@@ -198,6 +198,9 @@ public abstract class QueryTest extends TestCase {
         boolean even = true;
         do {
             String line = reader.readLine();
+            // ignore Flink tracing output
+            while (line != null && line.contains(" switched to "))
+                line = reader.readLine();
             if (line == null)
                 return s;
             for ( int i = 0; i < line.length(); i++ )
@@ -221,13 +224,13 @@ public abstract class QueryTest extends TestCase {
             MRData v2 = MRQL.query(line2);
             Config.hadoop_mode = hm;
             if (!equal_value(v1,v2)) {
-                System.err .println("*** "+file1+" (query "+i+"):\nFound: "+v1+"\nExpected: "+v2);
+                System.err.println("*** "+file1+" (query "+i+"):\nFound: "+v1+"\nExpected: "+v2);
                 return i;
             };
-            line1 = reader1.readLine();
-            line2 = reader2.readLine();
+            line1 = read_lines(reader1);
+            line2 = read_lines(reader2);
             i++;
-        } while (line1 != null && line2 != null);
+        } while (line1 != "" && line2 != "");
         return 0;
     }
 

--- a/flink/src/main/java/org/apache/mrql/FlinkDataSource.java
+++ b/flink/src/main/java/org/apache/mrql/FlinkDataSource.java
@@ -87,6 +87,20 @@ final public class FlinkDataSource extends DataSource implements Serializable {
                                                                ((Reducer)other).accumulated_value.data())));
         }
 
+        @Override
+        public Accumulator<FData, String> clone() {
+            Reducer reducer = new Reducer();
+
+            reducer.zero = new FData(this.zero.data);
+            reducer.accumulated_value = new FData(accumulated_value.data);
+            reducer.acc = this.acc;
+            reducer.merge = this.merge;
+            reducer.acc_fnc = this.acc_fnc;
+            reducer.merge_fnc = this.merge_fnc;
+
+            return reducer;
+        }
+
         public void write ( DataOutputView out ) throws IOException {
             accumulated_value.write(out);
             zero.write(out);

--- a/flink/src/main/java/org/apache/mrql/FlinkEvaluator.gen
+++ b/flink/src/main/java/org/apache/mrql/FlinkEvaluator.gen
@@ -35,6 +35,7 @@ import org.apache.flink.api.java.*;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.functions.*;
 import org.apache.flink.api.java.operators.*;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -190,7 +191,8 @@ public class FlinkEvaluator extends Evaluator implements Serializable {
     private static MRData aggregate ( DataSet<FData> data_set, MRData zero, Tree acc_fnc, Tree merge_fnc, Tree type ) {
         DataSet<FData> d = data_set.flatMap(new FlinkDataSource.reduce_mapper(zero,acc_fnc.toString(),
                                                                               merge_fnc.toString()));
-        d.print();  // needs a datasink (prints the aggregation value)
+        //d.print();  // needs a datasink (prints the aggregation value)
+        d.output(new DiscardingOutputFormat());
         try {
             // due to a Flink bug, we cannot return a custom object (FData) from an accumulator
             String value = FlinkEvaluator.flink_env.execute("MRQL aggregator").getAccumulatorResult("reducer");

--- a/flink/src/main/java/org/apache/mrql/FlinkStreaming.gen
+++ b/flink/src/main/java/org/apache/mrql/FlinkStreaming.gen
@@ -28,7 +28,8 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.util.Collector;
 import org.apache.flink.streaming.api.datastream.*;
-import org.apache.flink.streaming.api.function.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
@@ -47,12 +48,14 @@ public class FlinkStreaming extends FlinkEvaluator {
 	final private String directory;
         final private long time_window;
         final private FileInputFormat<FData> input_format;
+        private boolean is_running;
 
 	public MRDataFileSourceFunction ( String directory, long time_window,
                                           FileInputFormat<FData> input_format ) {
             this.directory = directory;
             this.time_window = time_window;
             this.input_format = input_format;
+            this.is_running = false;
 	}
 
         /** return the files within the directory that have been created within the last time window */
@@ -85,10 +88,10 @@ public class FlinkStreaming extends FlinkEvaluator {
         }
 
 	@Override
-	public void invoke ( Collector<FData> collector ) throws IOException {
+	public void run ( SourceContext<FData> context ) throws Exception {
             long tick = System.currentTimeMillis();
             file_modification_times = new HashMap<String,Long>();
-            while (true) {
+            while (is_running) {
                 for ( String path: new_files() ) {
                     input_format.setFilePath(path);
                     FileInputSplit[] splits = input_format.createInputSplits(1);
@@ -97,7 +100,7 @@ public class FlinkStreaming extends FlinkEvaluator {
                         while (!input_format.reachedEnd()) {
                             FData fd = input_format.nextRecord(container);
                             if (fd != null)
-                                collector.collect(fd);
+                                context.collect(fd);
                         }
                     };
                     input_format.close();
@@ -112,6 +115,11 @@ public class FlinkStreaming extends FlinkEvaluator {
                     return;
                 }
             }
+	}
+
+	@Override
+	public void cancel() {
+	  is_running = false;
 	}
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <hama.version>0.6.4</hama.version>
     <spark.version>1.3.1</spark.version>
     <scala.version>2.10</scala.version>
-    <flink.version>0.8.1</flink.version>
+    <flink.version>0.9.0</flink.version>
     <skipTests>true</skipTests>
   </properties>
 
@@ -143,6 +143,8 @@
           <excludes>
 	    <exclude>.git/**</exclude>
 	    <exclude>.gitignore</exclude>
+            <exclude>.idea/**</exclude>
+            <exclude>**.iml</exclude>
             <exclude>.classpath/**</exclude>
             <exclude>.project/**</exclude>
             <exclude>tests/data/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <hadoop.version>1.2.1</hadoop.version>
-    <yarn.version>2.2.0</yarn.version>
+    <yarn.version>2.6.0</yarn.version>
     <hama.version>0.6.4</hama.version>
     <spark.version>1.3.1</spark.version>
     <scala.version>2.10</scala.version>


### PR DESCRIPTION
Added some more changes to pass the JIRA tests: Changed the QueryTest class to ignore the tracing output from Flink 0.9.0. Now flink mode passes all tests. Updated the pom and config files to use Flink 0.9.0 by default. Now MRQL cannot compile in other Flink versions.